### PR TITLE
redirect instead of broken iframe

### DIFF
--- a/sponsorship-packet.html
+++ b/sponsorship-packet.html
@@ -1,12 +1,4 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
-  <head>
-    <meta charset="utf-8">
-    <title>Sponsorship Packet</title>
-    <link rel="stylesheet" href="style/sponsorship_packet.css">
-  </head>
-  <body>
-    <iframe class="sponsorship-packet"
-            src="https://storage.googleapis.com/ugahacks-public/external/UH7SponsorshipPacket.pdf"></iframe>
-  </body>
-</html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<meta http-equiv="refresh" content="0; URL=https://storage.googleapis.com/ugahacks-public/external/UH7SponsorshipPacket.pdf">


### PR DESCRIPTION
Change the broken iframe to a redirect to the stable googleapis URI for the packet.